### PR TITLE
Fix string value of trainsit.train_stations.platform

### DIFF
--- a/specification-1.0.md
+++ b/specification-1.0.md
@@ -243,10 +243,10 @@ String values are text-based identifiers of venue categories. Dependencies on pa
 
 ### Transit: Train Stations
 
-| Grandchild Category | Category Definition | Enumeration ID | String Value                    |
-| ------------------- | ------------------- | -------------- | ------------------------------- |
-| Train               | TBC                 | 10601          | transit.train\_stations.train   |
-| Platform            | TBC                 | 10602          | transit.train\_station.platform |
+| Grandchild Category | Category Definition | Enumeration ID | String Value                     |
+| ------------------- | ------------------- | -------------- | -------------------------------- |
+| Train               | TBC                 | 10601          | transit.train\_stations.train    |
+| Platform            | TBC                 | 10602          | transit.train\_stations.platform |
 
 ### Retail: Gas Stations
 


### PR DESCRIPTION
Noticed a typo in the string value of trainsit.train_station**s**.platform