### PR TITLE
Lucit fix to college grandchildren ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+.env
+.env.local
+.env.test
+.env.production.local
+.env.development.local
+.env.credentials
+
+.vscode
+
+/node_modules
+/vendor
+
+/build
+/coverage
+/release

--- a/specification-1.1-draft1.md
+++ b/specification-1.1-draft1.md
@@ -306,9 +306,9 @@ In order to ease forwards-compatibility, internationalization, and consistency a
 
 | Grandchild Category   | Category Definition                                    | Enumeration ID | String Value (Deprecated)               |
 | --------------------- | ------------------------------------------------------ | -------------- | --------------------------------------- |
-| Residences            | Places where faculty or students live                  | 60101          | education.colleges.residences           |
-| Common Areas          | Shared spaces for study, dining, or leisure activities | 60102          | education.colleges.common               |
-| Athletic Facilities   | Facillities or stadiums for sporting competition       | 60103          | education.colleges.athletics            |
+| Residences            | Places where faculty or students live                  | 60201          | education.colleges.residences           |
+| Common Areas          | Shared spaces for study, dining, or leisure activities | 60202          | education.colleges.common               |
+| Athletic Facilities   | Facillities or stadiums for sporting competition       | 60203          | education.colleges.athletics            |
 
 ### Office Buildings: Office Buildings
 


### PR DESCRIPTION
@ericlucit
Fixed the enumeration_ids for the grandchildren of Colleges and Universities

The Colleges and Universities category is ID `602` but its grandchildren were listed as `60101`,`60102`,`60103`

This fixes the ids to have the correct `602` prefix

Also, added a generic `.gitignore` - Which will be needed for potential future tools, etc.   If you don't want this yet, it can be removed
