### PR TITLE
Add The Neuron to adoption list

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ Resources
 | Verizon Media | Production | 1.0 | Supports OpenOOH v1.0.0 as of 10/1/20 |
 | VIOOH | Evaluating | 1.0 |  |
 | Vistar Media | Production | 1.0 | Supports OpenOOH v1.0.0 (parent/child levels only) as of 9/9/20
+| The Neuron | Production | 1.1 | Supports OpenOOH v1.0.0 as of 21/Oct/2021 - updated for 1.1 Dec/2022 |


### PR DESCRIPTION
The Neuron DSP  has been using OpenOOH/venue-taxonomy since 2021.