### PR TITLE
Update specification-1.2.md

### DIFF
--- a/specification-1.2.md
+++ b/specification-1.2.md
@@ -77,18 +77,15 @@ Venues can be assigned to a grandchild but are optional and at the purview of th
 
 ## Placement in Bid Requests
 
-In terms of placing venue types, this specification suggests placing venue type information in the device object of an OpenRTB 2.6 `bid_request`. The path would lead into an extension and a subsequent dooh object. The declaration of format is implicit to one the following formats:
+In terms of placing venue types, this specification suggests placing venue type information in the dooh object of an OpenRTB 2.6 `bid_request`. The declaration of format is implicit to the following format:
 
-* `device.ext.dooh.venuetypelist` (equivalent to `venuetypeid` and any parent-categories of the chosen venue)
-* `device.ext.dooh.venuetypeid`
+* `dooh.venuetypeid`
 
 ### Implementation Notes:
 
 The values represented in file exports, or `bid_request` should identify the single (best) venue describing the the context and surroundings for where advertising will display. In the event there are multiple classifications in the taxonomy that could apply, media owners should choose the single value most likely to match advertisers expectations.
 
 DSPs receiving bid_reqeusts with unknown categories (e.g. from an SSP sending categories from a more recent version of the specification) should process the `bid_request` as if the category was not present. 
-* In the case of a `bid_request` passing only `venuetypeid` this would be equivalent to a request with no defined venue category.
-* In the event of a request with `venuetypelist`, if some of the categories in the hierarchy are known, this would be equivalent to a request with just the known parent categories passed (e.g. [`leisure`, `unknown category`] would be interpreted as equivalent to [`leisure`]
 
 ## Value Format
 


### PR DESCRIPTION
updated language around ortb 2.6, specifically handling of DOOH object. previous language had venuetypeid declared via an ext field. this update shows the mainlining of the dooh object and updated handling of dooh.venuetypeid