### PR TITLE
Update string value for restroom category

### DIFF
--- a/specification-1.2.md
+++ b/specification-1.2.md
@@ -561,7 +561,7 @@ The enumerated list can be passed in the bid request. It is a comma-separated ar
 
 | Grandchild Category | Category Definition | Enumeration ID | String Value (Deprecated)            |
 | ------------------- | ------------------- | -------------- | ------------------------------------ |
-| Restroom         | The restroom of a large building or complex of buildings designed to host conventions, trade shows, exhibitions, and other large-scale events         |  81201          | entertainment.casino.restroom
+| Restroom         | The restroom of a large building or complex of buildings designed to host conventions, trade shows, exhibitions, and other large-scale events         |  81201          | entertainment.convention_center.restroom
 
 ### Residential: Apartment Building and Condominium
 


### PR DESCRIPTION
Two restroom categories under Entertainment > Casino

Wrong:
```
      {
        "id": 81101,
        "name": "Restroom",
        "code": "entertainment.casino.restroom",
        "parentId": 811,
        "level": "grandchild"
      },
      {
        "id": 81201,
        "name": "Restroom",
        "code": "entertainment.casino.restroom",
        "parentId": 812,
        "level": "grandchild"
      },
```      
Corrected:
```
      {
        "id": 81101,
        "name": "Restroom",
        "code": "entertainment.casino.restroom",
        "parentId": 811,
        "level": "grandchild"
      },
      {
        "id": 81201,
        "name": "Restroom",
        "code": "entertainment.convention_center.restroom",
        "parentId": 812,
        "level": "grandchild"
      },
```